### PR TITLE
feat: add proxy support and prerelease version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 * 0.1.0 (2023-05-13): Initial release
 * 0.2.0 (2023-05-13): Replace [`colored`] dependency with [`bunt`]; use [`clap`] subcommand
-* 0.3.0 (2023-05-14): Add `Crates::crates()` method to simplify usage; update dependencies; add examples to readme; add changelog; change description
+* 0.3.0 (2023-05-14): Add `Crates::crates()` method to simplify usage; update dependencies; add examples to readme; add
+  changelog; change description
     * 0.3.1 (2023-05-14): Fix readme
     * 0.3.2 (2023-05-14): Clean up; remove old dependency [`pager`] *yanked*
     * 0.3.3 (2023-05-14): Fix version
@@ -15,20 +16,29 @@
 * 0.7.0 (2023-05-24): Add `--readme` option
 * 0.8.0 (2023-10-08): Add `--update-all` option and `Crate.update_force()` method; update dependencies
     * 0.8.1 (2023-10-08): Fix readme
-* 0.9.0 (2023-11-06): Miscellaneous fixes for recent changes to [`kapow`]; added [`Makefile.md`] for [`mkrs`]; updated dependencies
+* 0.9.0 (2023-11-06): Miscellaneous fixes for recent changes to [`kapow`]; added [`Makefile.md`] for [`mkrs`]; updated
+  dependencies
 * 0.10.0 (2023-11-21): Add summary after updates; update dependencies
     * 0.10.1 (2023-11-21): Fix readme/changelog
 * 0.11.0 (2023-11-29): Remove dev dependency on kapow; remove [`pager`] on windows
-* 0.12.0 (2023-12-13): Use the user's `~/.cargo/.crates2.json` instead of running `cargo install --list` and parsing; list local and git crates; enable short options; add `-k`, `-a`, `-c` options; remove the `--update-all` option; report total number of crates or number of outdated crates; remove examples; update dependencies
+* 0.12.0 (2023-12-13): Use the user's `~/.cargo/.crates2.json` instead of running `cargo install --list` and parsing;
+  list local and git crates; enable short options; add `-k`, `-a`, `-c` options; remove the `--update-all` option;
+  report total number of crates or number of outdated crates; remove examples; update dependencies
 * 0.13.0 (2023-12-13): Fix the `cargo install` command to update a crate; add library docstrings; general cleanup
     * 0.13.1 (2023-12-13): Replace the changelog in the readme with a link
 * 0.14.0 (2023-12-14): Add library usage example to readme, module doc, and integration test
     * 0.14.1 (2023-12-14): Fix external crate count
     * 0.14.2 (2023-12-14): Fix another external crate count
-* 0.15.0 (2023-12-14): Clarify and expose the `latest` function; split the `Crates::crates` method to enable getting views of `all` or `outdated` crates separately; improve doc
+* 0.15.0 (2023-12-14): Clarify and expose the `latest` function; split the `Crates::crates` method to enable getting
+  views of `all` or `outdated` crates separately; improve doc
 * 0.16.0 (2023-12-15): Add the `-R` and `-n` options; add CLI examples to readme
-* 0.17.0 (2023-12-15): Replace `Crates`' repetitive `all` and `outdated` methods with a better `crates` method; display the active toolchain with `-R`; replace the `Crate::update` method with a `run` function and halt if an update fails; add the `-I` option; improve the `latest` function to process an optional version requirement and use the REST API instead of the `cargo search` command to get all available versions
-* 0.18.0 (2023-12-18): Replace markdown output lists with colorized tables using [`veg`]; eliminate [`bunt`] and [`is-terminal`] dependencies and use `veg::colored` re-exported [`colored`] `ColoredString` and `Colorized` instead; update dependencies
+* 0.17.0 (2023-12-15): Replace `Crates`' repetitive `all` and `outdated` methods with a better `crates` method; display
+  the active toolchain with `-R`; replace the `Crate::update` method with a `run` function and halt if an update fails;
+  add the `-I` option; improve the `latest` function to process an optional version requirement and use the REST API
+  instead of the `cargo search` command to get all available versions
+* 0.18.0 (2023-12-18): Replace markdown output lists with colorized tables using [`veg`]; eliminate [`bunt`] and [
+  `is-terminal`] dependencies and use `veg::colored` re-exported [`colored`] `ColoredString` and `Colorized` instead;
+  update dependencies
     * 0.18.1 (2023-12-18): Don't print an empty table; update dependencies
 * 0.19.0 (2023-12-19): Add spinner; update dependencies
 * 0.20.0 (2023-12-24): Use [`sprint`] shell; update dependencies
@@ -43,7 +53,8 @@
     * 0.22.1 (2024-01-06): Fix missing rust version if outdated
 * 0.23.0 (2024-01-06): Add level 2 heading for each crate updated
     * 0.23.1 (2024-01-24): Fix message after updating; update dependencies
-* 0.24.0 (2024-02-17): Add pattern match include feature and `Crates::from_include` method via [`regex`]; update dependencies
+* 0.24.0 (2024-02-17): Add pattern match include feature and `Crates::from_include` method via [`regex`]; update
+  dependencies
     * 0.24.1 (2024-03-11): Update dependencies
 * 0.25.0 (2024-04-14): Print a better summary after updating; update dependencies
     * 0.25.1 (2024-07-30): Fix makefile; update dependencies
@@ -52,16 +63,23 @@
 * 0.26.0 (2024-10-24): Add clap color; update dependencies
     * 0.26.1 (2024-12-04): Update dependencies
 * 0.27.0 (2024-12-05): Update git crates if `-a` or `-k git`; fix changelog; update dependencies
-* 0.28.0 (2025-01-23): Fix [issue #1](https://github.com/qtfkwk/cargo-list/issues/1) (exclude yanked crates from being considered as available versions); update dependencies
+* 0.28.0 (2025-01-23): Fix [issue #1](https://github.com/qtfkwk/cargo-list/issues/1) (exclude yanked crates from being
+  considered as available versions); update dependencies
 * 0.29.0 (2025-01-24): Deserialize available crate versions via API; lazily create reqwest client once; clean up
-    * 0.29.1 (2025-01-25): Fix [issue #3](https://github.com/qtfkwk/cargo-list/issues/3) (resolve the `error decoding response body` error); fix changelog; update dependencies
+    * 0.29.1 (2025-01-25): Fix [issue #3](https://github.com/qtfkwk/cargo-list/issues/3) (resolve the
+      `error decoding response body` error); fix changelog; update dependencies
 * 0.30.0 (2025-01-26): Add `Versions::available`, `Version::is_available` methods; error if no available versions
-* 0.31.0 (2025-02-05): Replace [`expanduser`] dependency with [`dirs`] to better support Windows (by [x807x] via [issue #4] / [PR #5]); update dependencies
+* 0.31.0 (2025-02-05): Replace [`expanduser`] dependency with [`dirs`] to better support Windows (by [x807x]
+  via [issue #4] / [PR #5]); update dependencies
     * 0.31.1 (2025-02-21): Update dependencies
-    * 0.31.2 (2025-03-04): Fix [issue #6](https://github.com/qtfkwk/cargo-list/issues/6) (Does not detect the active Rust version correctly); update dependencies
-    * 0.31.3 (2025-03-14): Fix [issue #7](https://github.com/qtfkwk/cargo-list/issues/7) (Still not detect the active Rust version correctly); update dependencies
+    * 0.31.2 (2025-03-04): Fix [issue #6](https://github.com/qtfkwk/cargo-list/issues/6) (Does not detect the active
+      Rust version correctly); update dependencies
+    * 0.31.3 (2025-03-14): Fix [issue #7](https://github.com/qtfkwk/cargo-list/issues/7) (Still not detect the active
+      Rust version correctly); update dependencies
     * 0.31.4 (2025-04-16): Update dependencies
-* 0.32.0 (2025-06-12): Change default value for `-c` to `$CARGO_HOME/.crates2.json` and use the `$CARGO_HOME` environment variable to find the `.cargo` folder; usually it's `~/.cargo` / `$HOME/.cargo` but in certain scenarios it could be different; update dependencies
+* 0.32.0 (2025-06-12): Change default value for `-c` to `$CARGO_HOME/.crates2.json` and use the `$CARGO_HOME`
+  environment variable to find the `.cargo` folder; usually it's `~/.cargo` / `$HOME/.cargo` but in certain scenarios it
+  could be different; update dependencies
 * 0.33.0 (2025-09-02): Update dependencies; 2024 edition
     * 0.33.1 (2025-10-27): Update dependencies; use `pager2`
     * 0.33.2 (2025-10-27): Remove rust workflow; failed
@@ -70,25 +88,40 @@
     * 0.33.5 (2025-11-11): Update dependencies
     * 0.33.6 (2025-11-14): Update dependencies; clippy fixes
     * 0.33.7 (2026-03-03): Update dependencies
+    * 0.33.8 (2026-03-12): Add `CARGO_LIST_PROXY` support; support checking updates for pre-release versions
 
 [`atty`]: https://crates.io/crates/atty
+
 [`bunt`]: https://crates.io/crates/bunt
+
 [`clap`]: https://crates.io/crates/clap
+
 [`clap-cargo`]: https://crates.io/crates/clap-cargo
+
 [`colored`]: https://crates.io/crates/colored
+
 [`dirs`]: https://crates.io/crates/dirs
+
 [`expanduser`]: https://crates.io/crates/expanduser
+
 [`is-terminal`]: https://crates.io/crates/is-terminal
+
 [`kapow`]: https://crates.io/crates/kapow
+
 [`mkrs`]: https://crates.io/crates/mkrs
+
 [`pager`]: https://crates.io/crates/pager
+
 [`regex`]: https://crates.io/crates/regex
+
 [`sprint`]: https://crates.io/crates/sprint
+
 [`veg`]: https://crates.io/crates/veg
 
 [`Makefile.md`]: Makefile.md
 
 [x807x]: https://github.com/x807x
-[issue #4]: https://github.com/qtfkwk/cargo-list/issues/4
-[PR #5]: https://github.com/qtfkwk/cargo-list/pull/5
 
+[issue #4]: https://github.com/qtfkwk/cargo-list/issues/4
+
+[PR #5]: https://github.com/qtfkwk/cargo-list/pull/5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -196,14 +196,13 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-list"
-version = "0.33.7"
+version = "0.33.8"
 dependencies = [
  "anyhow",
  "clap",
  "clap-cargo",
  "dirs",
  "indexmap",
- "lazy_static",
  "pager2",
  "rayon",
  "regex",
@@ -318,7 +317,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -435,7 +434,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -483,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -894,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "ignore-check"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e9d59499038db96003debd88a5fd5e449d68c2f2741725bc5acfa555cfdd7b"
+checksum = "fb5eaf082ccfd773e99d8ad7e08289b4245bf80718570a73d3ba241fe39db6e5"
 dependencies = [
  "anyhow",
  "ignore",
@@ -915,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags 2.11.0",
  "inotify-sys",
@@ -1031,9 +1030,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
@@ -1157,9 +1156,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "pager2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e30d5a40a266c984e42cd1182be3fbcd13b43ee60c190f5e406bfed986e7149f"
+checksum = "8b1e7893a80cce30b597edd1a0accd3c916cb103c22a57a471d196b4fc0be0e9"
 dependencies = [
  "errno",
  "libc",
@@ -1232,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1268,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1442,7 +1441,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1499,7 +1498,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1537,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -1651,9 +1650,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -1661,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "spinners"
-version = "4.1.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0ef947f358b9c238923f764c72a4a9d42f2d637c46e059dbd319d6e7cfb4f82"
+checksum = "071af1a9d34b78b8db3ca4424b0ea4d87052d607dbe96287aebaccd596cabc86"
 dependencies = [
  "lazy_static",
  "maplit",
@@ -2186,7 +2185,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2483,18 +2482,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cargo-list"
-version = "0.33.7"
+version = "0.33.8"
 edition = "2024"
 description = "List and update installed crates"
 repository = "https://github.com/qtfkwk/cargo-list"
 license = "MIT"
 readme = "README.md"
-keywords = [ "cargo", "install", "list", "update", "crates" ]
-categories = [ "development-tools::cargo-plugins", "command-line-utilities" ]
+keywords = ["cargo", "install", "list", "update", "crates"]
+categories = ["development-tools::cargo-plugins", "command-line-utilities"]
 
 [dependencies]
 anyhow = "1.0.102"
@@ -15,16 +15,15 @@ clap = { version = "4.5.60", features = ["derive", "wrap_help"] }
 clap-cargo = "0.18.3"
 dirs = "6.0.0"
 indexmap = { version = "2.13.0", features = ["rayon"] }
-lazy_static = "1.5.0"
 rayon = "1.11.0"
 regex = "1.12.3"
-reqwest = { version = "0.13.2", features = ["blocking", "json"] }
+reqwest = { version = "0.13.2", features = ["blocking", "json", "socks"] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-spinners = "4.1.1"
+spinners = "4.2.0"
 sprint = "0.12.4"
 veg = { version = "0.6.4", features = ["colored"] }
 
 [target.'cfg(unix)'.dependencies]
-pager2 = "0.6.3"
+pager2 = "0.6.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     let mut builder = Client::builder().user_agent("cargo-list");
 
     if let Ok(url) = std::env::var("CARGO_LIST_PROXY") {
-        eprintln!("- proxy is now {}", url);
         let proxy = reqwest::Proxy::all(&url).expect("CARGO_LIST_PROXY invalid");
         builder = builder.proxy(proxy);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //--------------------------------------------------------------------------------------------------
 
 use {
-    anyhow::{Result, anyhow},
+    anyhow::{Context, Result, anyhow},
     dirs::home_dir,
     rayon::prelude::*,
     regex::RegexSet,
@@ -21,10 +21,15 @@ use {
 //--------------------------------------------------------------------------------------------------
 
 static CLIENT: LazyLock<Client> = LazyLock::new(|| {
-    Client::builder()
-        .user_agent("cargo-list")
-        .build()
-        .expect("create reqwest client")
+    let mut builder = Client::builder().user_agent("cargo-list");
+
+    if let Ok(url) = std::env::var("CARGO_LIST_PROXY") {
+        eprintln!("- proxy is now {}", url);
+        let proxy = reqwest::Proxy::all(&url).expect("CARGO_LIST_PROXY invalid");
+        builder = builder.proxy(proxy);
+    }
+
+    builder.build().expect("create reqwest client")
 });
 
 //--------------------------------------------------------------------------------------------------
@@ -145,7 +150,11 @@ impl Crates {
         let errors = crates
             .installs
             .par_iter_mut()
-            .filter_map(|(k, v)| v.init(k, &crates.active_version).err())
+            .filter_map(|(k, v)| {
+                v.init(k, &crates.active_version)
+                    .with_context(|| format!("Failed to process crate '{k}'"))
+                    .err()
+            })
             .collect::<Vec<_>>();
         if errors.is_empty() {
             Ok(crates)
@@ -234,7 +243,11 @@ impl Crate {
         self.outdated_rust = self.rust_version != active_version;
 
         if self.kind == External {
-            (self.available, self.newer) = latest(&self.name, &self.version_req)?;
+            let installed_version = semver::Version::parse(&self.installed)?;
+            // If the installed version is a pre-release, we should include pre-releases in the search
+            let include_prerelease = !installed_version.pre.is_empty();
+            (self.available, self.newer) =
+                latest(&self.name, &self.version_req, include_prerelease)?;
             self.outdated = self.installed != self.available;
         }
 
@@ -310,8 +323,10 @@ impl Versions {
         self.versions.iter()
     }
 
-    fn available(&self) -> Vec<&Version> {
-        self.iter().filter(|x| x.is_available()).collect()
+    fn available(&self, include_prerelease: bool) -> Vec<&Version> {
+        self.iter()
+            .filter(|x| x.is_available(include_prerelease))
+            .collect()
     }
 }
 
@@ -322,8 +337,11 @@ struct Version {
 }
 
 impl Version {
-    fn is_available(&self) -> bool {
-        self.num.pre.is_empty() && !self.yanked
+    fn is_available(&self, include_prerelease: bool) -> bool {
+        if !include_prerelease && !self.num.pre.is_empty() {
+            return false;
+        }
+        !self.yanked
     }
 }
 
@@ -337,13 +355,18 @@ required version
 
 Returns an error if not able to get the versions via the REST API
 */
-pub fn latest(name: &str, version_req: &Option<String>) -> Result<(String, Vec<String>)> {
+pub fn latest(
+    name: &str,
+    version_req: &Option<String>,
+    include_prerelease: bool,
+) -> Result<(String, Vec<String>)> {
     let url = format!("https://crates.io/api/v1/crates/{name}/versions");
-    let res = CLIENT.get(url).send()?;
+    let res = CLIENT.get(&url).send()?;
+    let res = res.error_for_status()?;
     let versions = res.json::<Versions>()?;
-    let available = versions.available();
-    if let Some(req) = version_req {
-        let req = semver::VersionReq::parse(req)?;
+    let available = versions.available(include_prerelease);
+    if let Some(req_str) = version_req {
+        let req = semver::VersionReq::parse(req_str)?;
         let mut newer = vec![];
         for v in &available {
             if req.matches(&v.num) {
@@ -351,8 +374,24 @@ pub fn latest(name: &str, version_req: &Option<String>) -> Result<(String, Vec<S
             }
             newer.push(v.num.to_string());
         }
+        // If we haven't found a match yet, but we are allowing prereleases,
+        // it's possible the requirement string didn't explicitly opt-in to prereleases (like `^2.0.0`)
+        // but the available versions are prereleases (like `2.0.0-rc.37`).
+        // In this specific case, if we found *no* matching versions, we might want to be lenient,
+        // but semver::VersionReq is strict.
+
+        // However, if the user INSTALLED a prerelease, usually the version_req in .crates2.json
+        // reflects that (e.g. it might be `=2.0.0-rc.37` or `^2.0.0-rc.37`).
+        // If the error persists, it means even with prereleases included in `available`, none matched `req`.
+
         Err(anyhow!(
-            "Failed to find an available version matching the requirement"
+            "Failed to find an available version matching the requirement '{}' (available: {:?})",
+            req_str,
+            available
+                .iter()
+                .take(5)
+                .map(|v| v.num.to_string())
+                .collect::<Vec<_>>()
         ))
     } else if available.is_empty() {
         Err(anyhow!("Failed to find any available version"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,17 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     let mut builder = Client::builder().user_agent("cargo-list");
 
     if let Ok(url) = std::env::var("CARGO_LIST_PROXY") {
-        let proxy = reqwest::Proxy::all(&url).expect("CARGO_LIST_PROXY invalid");
-        builder = builder.proxy(proxy);
+        match reqwest::Proxy::all(&url) {
+            Ok(proxy) => {
+                builder = builder.proxy(proxy);
+            }
+            Err(err) => {
+                eprintln!(
+                    "warning: CARGO_LIST_PROXY is set but invalid ({}); ignoring proxy",
+                    err
+                );
+            }
+        }
     }
 
     builder.build().expect("create reqwest client")


### PR DESCRIPTION
feat: add proxy support and prerelease version handling

- Add `CARGO_LIST_PROXY` environment variable support for configuring HTTP/HTTPS proxy.
- Fallback to system proxy settings if `CARGO_LIST_PROXY` is not set.
- Enhance error reporting with crate name and HTTP status codes.
- Support checking for updates on pre-release versions (e.g., `rc`, `beta`) if the installed version is a pre-release.